### PR TITLE
Adding PAGER environment var to starterkit setup

### DIFF
--- a/starter-kits/wordpress/.env.sample
+++ b/starter-kits/wordpress/.env.sample
@@ -28,3 +28,8 @@ RUN_SCRIPTS=1
 # We're skipping it by default as it's not strictly required when using `volumes`
 # and it adds significantly to boot time with larger codebases.
 SKIP_CHOWN=1
+
+# This var ensures that output renders correctly when a program outputs content
+# to the console
+# See https://github.com/wp-cli/wp-cli/issues/3840#issuecomment-318067057
+PAGER=more


### PR DESCRIPTION
When running a command that has the docker container output stuff to the console (like `docker-compose exec wordpress wp help`), the command was outputting an error saying

```bash
less: unrecognized option: r
```

![screen shot 2018-06-18 at 4 01 56 pm](https://user-images.githubusercontent.com/3286676/41559111-11be80e6-7311-11e8-97be-0d812fbfb493.png)

Setting the environment variable `PAGER=more` fixes this.

Ref. https://github.com/wp-cli/wp-cli/issues/4246
