### PR TITLE
Add Blackfire to Docker setup for WordPress

### DIFF
--- a/starter-kits/wordpress/Dockerfile
+++ b/starter-kits/wordpress/Dockerfile
@@ -35,6 +35,15 @@ RUN wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.ph
 # Download WordPress
 RUN wp core download
 
+# Blackfire PHP probe
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # Copy custom configuration files into location expected by nginx-php-fpm.
 # See https://github.com/richarvey/nginx-php-fpm/blob/master/docs/nginx_configs.md
 COPY conf /var/www/html/conf

--- a/starter-kits/wordpress/docker-compose.yml
+++ b/starter-kits/wordpress/docker-compose.yml
@@ -25,6 +25,13 @@ services:
             MYSQL_DATABASE: wordpress
             MYSQL_USER: wordpress
             MYSQL_PASSWORD: wordpress
+    blackfire:
+        image: blackfire/blackfire
+        environment:
+            BLACKFIRE_CLIENT_ID: f97746c8-6219-4d69-88b1-36df77d0a38e
+            BLACKFIRE_CLIENT_TOKEN: 50d41e7e07b84a8de467324b0e0afab57f5d85547117fcbbed04f2b3424167a3
+            BLACKFIRE_SERVER_ID: 717b6c43-9257-4f18-8b7a-b8854f6b06ff
+            BLACKFIRE_SERVER_TOKEN: 01b91d13f54e5a91a27eb14824654813465a79ea9f7b2dd7083001839f1d73f1
 volumes:
     db_data:
 networks:


### PR DESCRIPTION
This adds [Blackfire](https://blackfire.io) to the WordPress starter kit of images to allow for an easier method of debugging PHP performance