### PR TITLE
Accessible running indicator

### DIFF
--- a/www/main.css
+++ b/www/main.css
@@ -1,5 +1,5 @@
 :root {
-  --white: #ffffff;
+  --white: #fff;
   --offWhite: #eff0f2;
   --black: #022144;
   --blue: #287cf9;
@@ -12,7 +12,6 @@
   --green: #28a745;
   --teal: #20c997;
   --cyan: #17a2b8;
-  --white: #fff;
   --gray: #6c757d;
   --gray-dark: #343a40;
   --primary: #007bff;


### PR DESCRIPTION
# Description

The current running indicator's on/off colors are hard to distinguish for red/green colorblind users. This change solves that by changing the off indicator to gray, and the on indicator to a pulsing green.

## Related issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test

Navigate to `https://ups.dock` with at least one running and one stopped project.
