### PR TITLE
Replace favicon URL

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <title>Ups Dock</title>
     <link rel="stylesheet" href="main.css" />
-    <link rel="icon" href="https://www.upstatement.com/static/img/favicon/favicon.ico" />
+    <link rel="icon" href="https://www.upstatement.com/icon.png" />
   </head>
 
   <body>


### PR DESCRIPTION
# Description

Favicon was referring to an old URL that doesn't exist anymore

## Related issues

#19 
