### PR TITLE
[Spike] Custom domains on ups.dock

### DIFF
--- a/bin/gen-certs.sh
+++ b/bin/gen-certs.sh
@@ -16,6 +16,7 @@ openssl req \
   -nodes \
   -x509 \
   -days 1825 \
+  -extensions req_extensions \
   -keyout certs/ups.dock.key \
   -out certs/ups.dock.crt
 

--- a/config/openssl.conf
+++ b/config/openssl.conf
@@ -40,3 +40,5 @@ nsComment              = "OpenSSL Generated Certificate"
 
 DNS.1 = ups.dock
 DNS.2 = *.ups.dock
+DNS.3 = bsotest.org
+DNS.4 = *.bsotest.org

--- a/config/openssl.conf
+++ b/config/openssl.conf
@@ -4,7 +4,6 @@ default_bits       = 2048
 default_keyfile    = server-key.pem
 distinguished_name = req_distinguished_name
 req_extensions     = req_extensions
-x509_extensions    = x509_extensions
 string_mask        = utf8only
 prompt             = no
 
@@ -26,19 +25,7 @@ keyUsage             = digitalSignature, keyEncipherment
 subjectAltName       = @alternate_names
 nsComment            = "OpenSSL Generated Certificate"
 
-[ x509_extensions ]
-
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid,issuer
-
-basicConstraints       = CA:FALSE
-keyUsage               = digitalSignature, keyEncipherment
-subjectAltName         = @alternate_names
-nsComment              = "OpenSSL Generated Certificate"
-
 [ alternate_names ]
 
 DNS.1 = ups.dock
 DNS.2 = *.ups.dock
-DNS.3 = bsotest.org
-DNS.4 = *.bsotest.org


### PR DESCRIPTION
This ports over some logic initially thought about during the BSO project to allow for us to set up any domain to access a site running on the ups.dock network.

A typical use case might be to be able to read a cookie set on a specific domain in our local environments to mock authentication (as was the case for BSO).

## To set up a custom domain

Note that this is also documented in [this doc](https://paper.dropbox.com/doc/Setting-up-custom-domains-with-ups.dock--BozK2RWw2TIKifh9AOtF1mweAg-BMC06cQb0GhmLctvf0CAx).

Assuming you have this branch checked out in your local ups.dock repository:

1. Add a DNS resolver to your machine for the domain you'd like to access:

    ```sh
    echo -e "nameserver 127.0.0.1\nport 53535\n" | sudo tee /etc/resolver/local.bso.org
    ```

2. Open up the `config/openssl.conf` config file in your local ups.dock repo and add your domain to the list of `alternate_names`:

    ```
    DNS.3 = local.bso.org
    ```

    > Note that the line should follow numerically after whatever the previous DNS record is.

3. Still in your local ups.dock repo, remove the existing certs and reinstall:

    ```sh
    rm certs/ups.dock.*
    ./bin/install.sh
    docker-compose up -d
    ```

4. In the docker-compose file of the project you'd like to access from your new domain, update the `environment` config to look for your new virtual host and to read the relevant cert:

    ```yaml
    environment:
        UPS_DOCK_NAME: BSO
        VIRTUAL_HOST: bso.ups.dock,local.bso.org
        CERT_NAME: ups.dock
        HTTPS_METHOD: noredirect
    ```

5. Restart your docker containers.
6. Confirm that you can access the site at your new domain.

## Questions

- Is there a more portable way to do this without the overhead of ups.dock?
- How can we extract the DNS records from the `alternate_names` section of the `openssl.conf` config so that its not in this project's source control?