### PR TITLE
Fixes Issue 23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM jwilder/nginx-proxy
 
 COPY config/nginx.conf /etc/nginx/conf.d/ups.conf
+COPY config/vhosts /etc/nginx/vhost.d
 COPY templates/index.json.tmpl Procfile /app/
 COPY www /var/www/html
 
 # Customize proxy-wide nginx configuration
 RUN { \
   echo 'client_max_body_size 100m;'; \
-  } > /etc/nginx/conf.d/proxy.conf
+} > /etc/nginx/conf.d/proxy.conf
 
 RUN set -ex; \
   chown -R www-data:www-data /var/www/html && \

--- a/bin/gen-certs.sh
+++ b/bin/gen-certs.sh
@@ -16,8 +16,8 @@ openssl req \
   -nodes \
   -x509 \
   -days 1825 \
-  -keyout certs/ups.dock_key.pem \
-  -out certs/ups.dock_crt.pem
+  -keyout certs/ups.dock.key \
+  -out certs/ups.dock.crt
 
 echo "Adding trusted certificate to system keychain..."
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain certs/ups.dock.crt

--- a/bin/gen-certs.sh
+++ b/bin/gen-certs.sh
@@ -16,8 +16,8 @@ openssl req \
   -nodes \
   -x509 \
   -days 1825 \
-  -keyout certs/ups.dock.key \
-  -out certs/ups.dock.crt
+  -keyout certs/ups.dock_key.pem \
+  -out certs/ups.dock_crt.pem
 
 echo "Adding trusted certificate to system keychain..."
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain certs/ups.dock.crt

--- a/config/vhosts/default
+++ b/config/vhosts/default
@@ -1,0 +1,4 @@
+proxy_buffering on;
+proxy_busy_buffers_size 512k;
+proxy_buffers 4 512k;
+proxy_buffer_size 256k;

--- a/config/vhosts/route.submain.com
+++ b/config/vhosts/route.submain.com
@@ -1,5 +1,5 @@
-# This is the default vhost configuration. It will be
-# used for all other vhosts
+# Provide a file matching the name of each vhost to override
+# in this case, the vhost would be `route.subdomain.com`
 
 # It is recommended to set proxy buffer sizes to only what is required,
 # therefore we highly suggest you reduce your default values. Your header


### PR DESCRIPTION
# Description
Provides support for uploading custom proxy settings to the `nginx-proxy` image via their [documentation](https://github.com/nginx-proxy/nginx-proxy#per-virtual_host)

## Related issues
#23 

## How to test
1. Create a request to a site connecting to ups.dock (cURL, fetch, etc). Ensure it is of large enough size to exceed nginx's default proxy buffer size 
2. Send the request
3. Request should return a successful response.
4. nginx logs should no longer eject `upstream sent too big header while reading response header from upstream` error
